### PR TITLE
docs: add contributor infrastructure  

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: A command, setup step, or code snippet that doesn't work
+labels: bug
+---
+
+## What's broken?
+
+<!-- Describe the issue clearly -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should happen -->
+
+## Actual behavior
+
+<!-- What actually happens -->
+
+## Environment
+
+- OS:
+- Node version (`node -v`):
+- Claude Code version (`claude --version`):

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,17 @@
+---
+name: Improvement suggestion
+about: A note, resource, or template that could be better
+labels: enhancement
+---
+
+## What would you improve?
+
+<!-- Which file / section? -->
+
+## Current state
+
+<!-- What does it say now? -->
+
+## Suggested change
+
+<!-- What should it say or do instead, and why? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## What does this PR do?
+
+<!-- One sentence summary -->
+
+## Related issue
+
+Closes #<!-- issue number -->
+
+## Type of change
+
+- [ ] Typo / small fix
+- [ ] Notes improvement
+- [ ] New template or resource
+- [ ] Bug fix in uigen project
+- [ ] Other (describe below)
+
+## Checklist
+
+- [ ] Change is focused on one concern
+- [ ] I've read `CONTRIBUTING.md`
+- [ ] No secrets or personal data included

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+Thanks for your interest in contributing! This is primarily a personal study workspace, but corrections, improvements, and additions are welcome.
+
+## Ways to Contribute
+
+- **Fix a mistake** — typos, broken commands, incorrect notes
+- **Improve resources** — `resources/cheatsheet.md`, `resources/tips-and-tricks.md`
+- **Add a template** — useful `CLAUDE.md` starters or custom commands under `templates/`
+- **Suggest a lesson note improvement** — if a note is unclear or incomplete
+
+## What to Avoid
+
+- Changes to `projects/uigen/` unless fixing a reproducible bug (it's a third-party course project)
+- Personal opinion rewrites of lesson notes — these are my study notes
+- Large restructuring PRs without prior discussion via an issue
+
+## Process
+
+1. **Open an issue first** for anything beyond a small fix — describe what you want to change and why.
+2. **Fork** the repo and create a branch from `main`:
+   ```bash
+   git checkout -b fix/typo-in-cheatsheet
+   ```
+3. Make your change. Keep it focused — one concern per PR.
+4. **Submit a PR** using the provided template. Link the related issue.
+5. PRs require at least one review before merging.
+
+## Branch Naming
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Bug fix / typo | `fix/<short-description>` | `fix/broken-setup-command` |
+| New content | `add/<short-description>` | `add/hooks-cheatsheet-entry` |
+| Update existing | `update/<short-description>` | `update/lesson-7-notes` |
+
+## Commit Messages
+
+Use the imperative mood, present tense:
+
+```
+fix: correct npm run setup command in cheatsheet
+add: custom command template for /test
+update: lesson 6 notes with GitHub Actions details
+```
+
+## Code of Conduct
+
+Be respectful and constructive. This is a learning space.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Claude Code in Action — Study Repository
 
+![Progress](https://img.shields.io/badge/progress-9%2F21%20lessons-blue)
+![License](https://img.shields.io/badge/license-MIT-green)
+![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen)
+
 > **Author:** [Mohamed Salem Ali](https://github.com/Mohamed-Salem-Ali)
 > **Course:** [Claude Code in Action](https://anthropic.skilljar.com/claude-code-in-action) — Anthropic Academy
 > **Started:** 2026-03-27
@@ -115,6 +119,16 @@ claude -p "add error handling to src/lib/auth.ts"
 ```
 
 See `resources/cheatsheet.md` for the full command reference.
+
+---
+
+## Contributing
+
+Corrections, improved notes, and new templates are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
+
+- Open an issue first for anything beyond a small fix
+- One concern per PR
+- Branch from `main`, name it `fix/`, `add/`, or `update/`
 
 ---
 

--- a/resources/conventional-commits.md
+++ b/resources/conventional-commits.md
@@ -1,0 +1,74 @@
+# Conventional Commits — Quick Reference
+
+> Spec: [conventionalcommits.org](https://www.conventionalcommits.org)
+
+## Format
+
+```
+<type>(<optional scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Types
+
+| Type | When to use |
+|------|-------------|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation only changes |
+| `style` | Formatting, missing semicolons — no logic change |
+| `refactor` | Code change that is neither a fix nor a feature |
+| `test` | Adding or fixing tests |
+| `chore` | Build process, dependency updates, tooling |
+| `perf` | Performance improvement |
+| `ci` | CI/CD configuration changes |
+| `revert` | Reverting a previous commit |
+
+## Examples
+
+```bash
+feat: add custom /review command template
+fix: correct npm run setup path in cheatsheet
+docs: add lesson 7 hooks notes
+chore: add .gitignore entry for .env files
+feat(uigen)!: replace mock model with real API call
+```
+
+## Breaking Changes
+
+Add `!` after the type, and/or add `BREAKING CHANGE:` in the footer:
+
+```
+feat!: rename API key env variable
+
+BREAKING CHANGE: ANTHROPIC_KEY is now ANTHROPIC_API_KEY
+```
+
+## Scopes (this repo)
+
+Use these optional scopes for clarity:
+
+| Scope | Covers |
+|-------|--------|
+| `notes` | Files under `notes/` |
+| `uigen` | Files under `projects/uigen/` |
+| `resources` | Files under `resources/` |
+| `templates` | Files under `templates/` |
+| `exercises` | Files under `exercises/` |
+| `ci` | `.github/` workflows |
+
+## Rules
+
+- Subject line: **imperative mood**, lowercase, no period at end
+- Max 72 characters in subject line
+- Body: explain *why*, not *what* (the diff shows what)
+- One logical change per commit
+
+## Why Conventional Commits?
+
+- Machine-readable → auto-generate changelogs
+- Clear intent at a glance in `git log`
+- Enables semantic versioning (`feat` = minor bump, `fix` = patch, `!` = major)


### PR DESCRIPTION
## What does this PR do?
                                                                        
  Adds the full contributor infrastructure: contributing guide, PR and    issue templates, conventional commits reference, and README             improvements.                                                                                                                                   ## Related issue                                                                                                                                Closes #1                                                             

  ## Type of change

  - [x] New template or resource

  ## Changes

  - `CONTRIBUTING.md` — process, branch naming, commit style guide      
  - `.github/PULL_REQUEST_TEMPLATE.md` — structured PR descriptions     
  - `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug reports     
  - `.github/ISSUE_TEMPLATE/improvement.md` — structured suggestions    
  - `resources/conventional-commits.md` — quick reference card
  - `README.md` — added badges and Contributing section

  ## Checklist

  - [x] Change is focused on one concern
  - [x] I've read `CONTRIBUTING.md`
  - [x] No secrets or personal data included